### PR TITLE
Collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ UpgradeLog.XML
 /MarioObjects/bin/Debug/MarioObjects.pdb
 /MarioObjects/bin/Debug/MarioObjects.vshost.exe
 /MarioObjects/bin/Debug/MarioObjects.vshost.exe.manifest
+/.vs/MarioObjects/v14/.suo

--- a/MarioObjects/Objects/GameObjects/FireBall.cs
+++ b/MarioObjects/Objects/GameObjects/FireBall.cs
@@ -68,17 +68,31 @@ namespace MarioObjects.Objects.GameObjects
                     } break;
                 case ObjectType.OT_Pirana:
                     {
-                        if (Type == FireBallType.FT_Mario)
+                        if (Type == FireBallType.FT_Mario
+                            && ((MonsterPiranah)g).Move != MonsterPiranah.PiranaMove.PM_None) // Only kill pirana if it's out of its pipe
                         {
                             ((MonsterPiranah)g).Visible = false;
                             ((MonsterPiranah)g).Live = false;
-
                         }
-
+                    } break;
+                // Handle fireball hitting Mario
+                case ObjectType.OT_Mario:
+                    {
+                      if (Type != FireBallType.FT_Mario) // Make sure it isn't Mario's fireball
+                      {
+                        Mario m = (Mario)g;
+                        if (!m.Blinking)
+                          if (m.Type == Mario.MarioType.MT_Big || m.Type == Mario.MarioType.MT_Fire)
+                          {
+                            m.Type = Mario.MarioType.MT_Small;
+                            m.StartBlinking();
+                            m.SetMarioProperties();
+                          }
+                      }
                     } break;
             }
 
-        }
+        } 
 
         public void RunFireBall(int x, int y, FireBallType T, FireBallDir D)
         {

--- a/MarioObjects/Objects/GameObjects/MonsterKoopa.cs
+++ b/MarioObjects/Objects/GameObjects/MonsterKoopa.cs
@@ -117,8 +117,27 @@ namespace MarioObjects.Objects.GameObjects
                             SetKoopaState(KoopaState.KS_ShieldMoving);
                         }
 
+                        // Size-down mario when colliding with a koopa
+                        if (State != KoopaState.KS_Shield) // but not in shield state
+                        {
+                          if (!(State == KoopaState.KS_ShieldMoving // Or that he's just set in motion
+                              && (DirX == -1 && c.Dir == CollisionDirection.CD_Left) || (DirX == 1 && c.Dir == CollisionDirection.CD_Right)))
+                          {
+                            Mario m = (Mario)g;
+                            if (c.Dir != CollisionDirection.CD_Down)
+                            {
+                              if (!m.Blinking)
+                                if (m.Type == Mario.MarioType.MT_Big || m.Type == Mario.MarioType.MT_Fire)
+                                {
+                                  m.Type = Mario.MarioType.MT_Small;
+                                  m.StartBlinking();
+                                  m.SetMarioProperties();
+                                }
+                            }
+                          }
                     } break;
             }
+          } 
         }
         public override void OnAnimate(object sender, EventArgs e)
         {

--- a/MarioObjects/Objects/GameObjects/MonsterPiranah.cs
+++ b/MarioObjects/Objects/GameObjects/MonsterPiranah.cs
@@ -20,7 +20,32 @@ namespace MarioObjects.Objects.GameObjects
         public FireBall Ball;
         public Boolean FireOnce = false;
 
-        public void SetDirection()
+    public override void Intersection(Collision c, GraphicObject g)
+    {
+      base.Intersection(c, g);
+
+      switch (g.OT)
+      {
+        case ObjectType.OT_Mario:
+          {
+            // Handle collision with Mario
+            if (Move != PiranaMove.PM_None) // Only if the pirana is out of its pipe
+            {
+              Mario m = (Mario)g;
+              if (!m.Blinking)
+                if (m.Type == Mario.MarioType.MT_Big || m.Type == Mario.MarioType.MT_Fire)
+                {
+                  m.Type = Mario.MarioType.MT_Small;
+                  m.StartBlinking();
+                  m.SetMarioProperties();
+                }
+            }
+          }
+          break;
+      }
+    }
+
+    public void SetDirection()
         {
             if (newx >= LevelGenerator.CurrentLevel.MarioObject.x)
                 Direction = PiranahDirection.PD_Left;


### PR DESCRIPTION
Handle downsizing of Mario from collisions with Koopa/Pirana/Fireball.
Allow Mario to hit a Pirana only when it is out of its pipe.