### PR TITLE
Fix warning V3022

### DIFF
--- a/MarioObjects/Logger.cs
+++ b/MarioObjects/Logger.cs
@@ -93,11 +93,9 @@ namespace Helper
                         edt_Log.Text = edt_Log.Text.Remove(0, Math.Min(edt_Log.TextLength, 1024));
                     }
 
-              if (using_text_box)
-                    {
-                        edt_Log.AppendText(msg);
-                        SendMessage(edt_Log.Handle, WM_VSCROLL, SB_BOTTOM, 0);
-                    }
+                    edt_Log.AppendText(msg);
+                    SendMessage(edt_Log.Handle, WM_VSCROLL, SB_BOTTOM, 0);
+                    
                 }
 		}
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning , found using PVS-Studio:

-  V3022 Expression 'using_text_box' is always true. Logger.cs 96

I think it not necessary check the `using_text_box` twice 